### PR TITLE
fix:now create-vue used version 11.0.0 ts tip var no used

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ export default function createConfig ({
       break
     case 'default-typescript':
       eslintConfig.extends.push('eslint:recommended')
-      addDependencyAndExtend('@vue/eslint-config-typescript')
+      addDependencyAndExtend('@vue/eslint-config-typescript/recommended')
       break
     case 'airbnb-javascript':
     case 'standard-javascript':


### PR DESCRIPTION
现在，create-vue 使用的 [eslint-config-typescript](https://github.com/vuejs/eslint-config-typescript) 版本是 11.0.0 在vue的 script lange="ts" 中有 var no used 的错误提示。