### PR TITLE
fix: create initial prettier config matching the content of the generated files

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,7 +143,13 @@ export default function createConfig ({
   }
   if (needsPrettier) {
     // Prettier recommends an explicit configuration file to let the editor know that it's used.
-    files['.prettierrc.json'] = prettierrcs[styleGuide] || '{}'
+    files['.prettierrc.json'] = prettierrcs[styleGuide] || `{
+  "semi": false,
+  "tabWidth": 2,
+  "singleQuote": true,
+  "printWidth": 100,
+  "trailingComma": "none"
+}`
   }
 
   return {


### PR DESCRIPTION
We currently create an empty prettier config if no specific eslint style (standard/airbnb) is used.

But an empty prettier config does not match the code generated from `create-vue`'s template, i.e. the code uses single quotes, but prettier's default is `singleQuotes: false`

This PR copies over the pretttier config used in the `create-vue`codebase (with which the template source files were formatted) to create a config that matches the style present in the generated project.