### PR TITLE
feat: add `cache` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,10 +53,10 @@ export default function createConfig({
       ],
     })
     pkg.scripts['lint:oxlint'] = 'oxlint . --fix -D correctness --ignore-path .gitignore'
-    pkg.scripts['lint:eslint'] = 'eslint . --fix'
+    pkg.scripts['lint:eslint'] = 'eslint . --fix --cache'
     pkg.scripts.lint = 'run-s lint:*'
   } else {
-    pkg.scripts.lint = 'eslint . --fix'
+    pkg.scripts.lint = 'eslint . --fix --cache'
   }
 
   if (needsPrettier) {


### PR DESCRIPTION
The `--cache` option is very commonly used and has a very obvious effect. I think we can add it when creating related script commands.